### PR TITLE
fix for hybrid networks

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -181,7 +181,7 @@ fn main() {
     println!("Using interface: {}\n", interface);
 
     let source_mac = interface.mac_address();
-    let source_network = interface.ips.first().unwrap();
+    let source_network = interface.ips.iter().find(|x| x.is_ipv4()).unwrap();
     let source_ip = source_network.ip();
     let arp_operation = ArpOperations::Request;
     let target_mac = MacAddr::new(255,255,255,255,255,255);


### PR DESCRIPTION
Tried the tool on my network which had both an IPv4 and IPv6 address. It didn't work because the IPv6 address was selected instead of the IPv4 one. This fixes that. :)